### PR TITLE
Release version 2.1.1

### DIFF
--- a/CMPComapiFoundation.podspec
+++ b/CMPComapiFoundation.podspec
@@ -19,6 +19,6 @@ For more information about the integration please visit [the website](http://doc
   s.preserve_path         = 'Sources/Module/CMPComapiFoundation.modulemap'
   s.module_name           = s.name
   s.resources             = []
-
+  s.resource_bundles      = {'CMPComapiFoundation' => ['PrivacyInfo.xcprivacy']}
   s.dependency 'SocketRocket'
 end

--- a/CMPComapiFoundation.podspec
+++ b/CMPComapiFoundation.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.version = '2.1.0'
+  s.version = '2.1.1'
   s.name             =  'CMPComapiFoundation'
   s.license          = 	'MIT'
   s.summary          =	'Foundation library for connecting to and consuming COMAPI services'

--- a/CMPComapiFoundation.xcodeproj/project.pbxproj
+++ b/CMPComapiFoundation.xcodeproj/project.pbxproj
@@ -3454,7 +3454,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comapi.foundation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3479,7 +3479,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comapi.foundation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3831,7 +3831,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.1.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.comapi.foundation;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/CMPComapiFoundation.xcodeproj/project.pbxproj
+++ b/CMPComapiFoundation.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		31276AA5275E5C4E005B770F /* CMPAnalyticsService.h in Headers */ = {isa = PBXBuildFile; fileRef = 31276AA3275E5C4E005B770F /* CMPAnalyticsService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		31276AA6275E5C4E005B770F /* CMPAnalyticsService.m in Sources */ = {isa = PBXBuildFile; fileRef = 31276AA4275E5C4E005B770F /* CMPAnalyticsService.m */; };
+		31524BAB2CA2A8D7002D0CFB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 31524BAA2CA2A8D7002D0CFB /* PrivacyInfo.xcprivacy */; };
+		31524BAC2CA2A8D7002D0CFB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 31524BAA2CA2A8D7002D0CFB /* PrivacyInfo.xcprivacy */; };
 		338510D20824636FEA321A93 /* Pods_Shared_CMPComapiFoundation_ComapiFoundationSample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4BDB8BCE917DEF160301F932 /* Pods_Shared_CMPComapiFoundation_ComapiFoundationSample.framework */; };
 		3536280807D8F2019B73AA5D /* Pods_Shared_CMPComapiFoundation_ComapiFoundationSample_Swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55324D3FDF252D6EBD605881 /* Pods_Shared_CMPComapiFoundation_ComapiFoundationSample_Swift.framework */; };
 		47F2A1914884025F30673947 /* Pods_Shared_CMPComapiFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 704B88815E35D424AF1AB732 /* Pods_Shared_CMPComapiFoundation.framework */; };
@@ -477,6 +479,7 @@
 		30B75F391F464226716D4388 /* Pods-Shared-CMPComapiFoundation-ComapiFoundationSample-Swift.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-CMPComapiFoundation-ComapiFoundationSample-Swift.debug.xcconfig"; path = "Target Support Files/Pods-Shared-CMPComapiFoundation-ComapiFoundationSample-Swift/Pods-Shared-CMPComapiFoundation-ComapiFoundationSample-Swift.debug.xcconfig"; sourceTree = "<group>"; };
 		31276AA3275E5C4E005B770F /* CMPAnalyticsService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CMPAnalyticsService.h; sourceTree = "<group>"; };
 		31276AA4275E5C4E005B770F /* CMPAnalyticsService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CMPAnalyticsService.m; sourceTree = "<group>"; };
+		31524BAA2CA2A8D7002D0CFB /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		31FC39FCD8B6E955AEB4B521 /* Pods-Shared-CMPComapiFoundation-ComapiFoundationSample-Swift.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-CMPComapiFoundation-ComapiFoundationSample-Swift.staging.xcconfig"; path = "Target Support Files/Pods-Shared-CMPComapiFoundation-ComapiFoundationSample-Swift/Pods-Shared-CMPComapiFoundation-ComapiFoundationSample-Swift.staging.xcconfig"; sourceTree = "<group>"; };
 		3A5BA3D1C2D8A8D2385C8545 /* Pods-Shared-CMPComapiFoundation.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Shared-CMPComapiFoundation.staging.xcconfig"; path = "Target Support Files/Pods-Shared-CMPComapiFoundation/Pods-Shared-CMPComapiFoundation.staging.xcconfig"; sourceTree = "<group>"; };
 		4BDB8BCE917DEF160301F932 /* Pods_Shared_CMPComapiFoundation_ComapiFoundationSample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Shared_CMPComapiFoundation_ComapiFoundationSample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2020,6 +2023,7 @@
 		89C8DE342122DF3C00555495 = {
 			isa = PBXGroup;
 			children = (
+				31524BAA2CA2A8D7002D0CFB /* PrivacyInfo.xcprivacy */,
 				8921D2C9215520D100976FFA /* CMPComapiFoundationTests */,
 				8921D2C4215520C400976FFA /* CMPComapiFoundation */,
 				89EA5D04214ACCB700C29D08 /* Tests */,
@@ -2922,6 +2926,7 @@
 				89E01D4E231685C0005F6A77 /* (null) in Resources */,
 				89E01D51231685C0005F6A77 /* (null) in Resources */,
 				89E01D50231685C0005F6A77 /* (null) in Resources */,
+				31524BAB2CA2A8D7002D0CFB /* PrivacyInfo.xcprivacy in Resources */,
 				89E01D4B231685C0005F6A77 /* (null) in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2930,6 +2935,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				31524BAC2CA2A8D7002D0CFB /* PrivacyInfo.xcprivacy in Resources */,
 				89E459E021ABFDDD002C26AE /* LaunchScreen.storyboard in Resources */,
 				89E459DD21ABFDDD002C26AE /* Assets.xcassets in Resources */,
 			);

--- a/CMPComapiFoundation/Info.plist
+++ b/CMPComapiFoundation/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>102</string>
 </dict>

--- a/CMPComapiFoundationTests/Info.plist
+++ b/CMPComapiFoundationTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>102</string>
 </dict>

--- a/ComapiFoundationSample-Swift/Info.plist
+++ b/ComapiFoundationSample-Swift/Info.plist
@@ -29,7 +29,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>123</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ComapiFoundationSample/Info.plist
+++ b/ComapiFoundationSample/Info.plist
@@ -29,7 +29,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-    <string>2.1.0</string>
+	<string>2.1.1</string>
 	<key>CFBundleVersion</key>
 	<string>123</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false />
+    <key>NSPrivacyTrackingDomains</key>
+    <array />
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyCollectedDataType</key>
+        <string>NSPrivacyCollectedDataTypeUserID</string>
+        <key>NSPrivacyCollectedDataTypeLinked</key>
+        <true />
+        <key>NSPrivacyCollectedDataTypeTracking</key>
+        <false />
+        <key>NSPrivacyCollectedDataTypePurposes</key>
+        <array>
+          <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+        </array>
+      </dict>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>CA92.1</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/Sources/Core/Constants/CMPConstants.m
+++ b/Sources/Core/Constants/CMPConstants.m
@@ -50,7 +50,7 @@ CMPHTTPHeaderType const CMPHTTPHeaderAuthorization = @"Authorization";
 CMPHTTPHeaderType const CMPHTTPHeaderIfMatch = @"If-Match";
 
 CMPSDKInfo const CMPSDKInfoPlatform = @"iOS";
-CMPSDKInfo const CMPSDKInfoVersion = @"2.1.0";
+CMPSDKInfo const CMPSDKInfoVersion = @"2.1.1";
 CMPSDKInfo const CMPSDKInfoType = @"native";
 
 CMPQueueName const CMPQueueNameConsole = @"com.comapi.foundation.console";


### PR DESCRIPTION
Version 2.1.1 of Foundation SDK. Contains privacy manifest file PrivacyInfo.xcprivacy according to Apple [requirements](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).  